### PR TITLE
Update no-attr rule for setting attributes

### DIFF
--- a/rules/no-attr.js
+++ b/rules/no-attr.js
@@ -9,9 +9,10 @@ module.exports = function(context) {
       if (node.callee.property.name !== 'attr') return
 
       if (utils.isjQuery(node)) {
+        const getOrSet = node.arguments.length === 2 ? 'set' : 'get'
         context.report({
           node: node,
-          message: 'Prefer getAttribute to $.attr'
+          message: `Prefer ${getOrSet}Attribute to $.attr`
         })
       }
     }

--- a/tests/no-attr.js
+++ b/tests/no-attr.js
@@ -3,7 +3,8 @@
 const rule = require('../rules/no-attr')
 const RuleTester = require('eslint').RuleTester
 
-const error = 'Prefer getAttribute to $.attr'
+const getError = 'Prefer getAttribute to $.attr'
+const setError = 'Prefer setAttribute to $.attr'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-attr', rule, {
@@ -11,19 +12,27 @@ ruleTester.run('no-attr', rule, {
   invalid: [
     {
       code: '$("div").attr()',
-      errors: [{message: error, type: 'CallExpression'}]
+      errors: [{message: getError, type: 'CallExpression'}]
     },
     {
       code: '$div.attr()',
-      errors: [{message: error, type: 'CallExpression'}]
+      errors: [{message: getError, type: 'CallExpression'}]
     },
     {
       code: '$("div").first().attr()',
-      errors: [{message: error, type: 'CallExpression'}]
+      errors: [{message: getError, type: 'CallExpression'}]
     },
     {
       code: '$("div").append($("input").attr())',
-      errors: [{message: error, type: 'CallExpression'}]
+      errors: [{message: getError, type: 'CallExpression'}]
+    },
+    {
+      code: '$("div").attr("name")',
+      errors: [{message: getError, type: 'CallExpression'}]
+    },
+    {
+      code: '$("div").attr("name", "random")',
+      errors: [{message: setError, type: 'CallExpression'}]
     }
   ]
 })


### PR DESCRIPTION
This PR updates the `no-attr` rule to differentiate between getting an attribute and setting its value:
```js
// Error: Prefer getAttribute to $.attr
$('node').attr('name');
// Error: Prefer setAttribute to $.attr
$('node').attr('name', 'random');
```
Updated the tests to reflect that as well.

Fixes #15 