### PR TITLE
Refactor to use new rule format

### DIFF
--- a/rules/no-ajax-events.js
+++ b/rules/no-ajax-events.js
@@ -15,28 +15,33 @@ const disallowedEvents = {
 const MemberExpression = 'MemberExpression'
 const Literal = 'Literal'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (
-        node.callee.type === MemberExpression &&
-        node.callee.property.name === methodName &&
-        node.arguments.length >= 1
-      ) {
-        const arg = node.arguments[0]
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
+
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
         if (
-          arg.type === Literal &&
-          arg.value in disallowedEvents &&
-          utils.isjQuery(node)
+          node.callee.type === MemberExpression &&
+          node.callee.property.name === methodName &&
+          node.arguments.length >= 1
         ) {
-          context.report({
-            node: node,
-            message: `Prefer remoteForm to ${arg.value}`
-          })
+          const arg = node.arguments[0]
+          if (
+            arg.type === Literal &&
+            arg.value in disallowedEvents &&
+            utils.isjQuery(node)
+          ) {
+            context.report({
+              node: node,
+              message: `Prefer remoteForm to ${arg.value}`
+            })
+          }
         }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-ajax.js
+++ b/rules/no-ajax.js
@@ -1,25 +1,30 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      const name = node.callee.property.name
-      switch (name) {
-        case 'ajax':
-        case 'get':
-        case 'getJSON':
-        case 'getScript':
-        case 'post':
-          context.report({
-            node: node,
-            message: 'Prefer fetch to $.' + name
-          })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+
+        const name = node.callee.property.name
+        switch (name) {
+          case 'ajax':
+          case 'get':
+          case 'getJSON':
+          case 'getScript':
+          case 'post':
+            context.report({
+              node: node,
+              message: 'Prefer fetch to $.' + name
+            })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-animate.js
+++ b/rules/no-animate.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'animate') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.animate is not allowed'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'animate') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.animate is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-attr.js
+++ b/rules/no-attr.js
@@ -2,21 +2,26 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'attr') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        const getOrSet = node.arguments.length === 2 ? 'set' : 'get'
-        context.report({
-          node: node,
-          message: `Prefer ${getOrSet}Attribute to $.attr`
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'attr') return
+
+        if (utils.isjQuery(node)) {
+          const getOrSet = node.arguments.length === 2 ? 'set' : 'get'
+          context.report({
+            node: node,
+            message: `Prefer ${getOrSet}Attribute to $.attr`
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-bind.js
+++ b/rules/no-bind.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'bind') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer addEventListener to $.bind'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'bind') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer addEventListener to $.bind'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-class.js
+++ b/rules/no-class.js
@@ -2,22 +2,27 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  const forbidden = ['addClass', 'hasClass', 'removeClass', 'toggleClass']
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (forbidden.indexOf(node.callee.property.name) === -1) return
+  create: function(context) {
+    const forbidden = ['addClass', 'hasClass', 'removeClass', 'toggleClass']
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer classList to $.' + node.callee.property.name
-        })
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (forbidden.indexOf(node.callee.property.name) === -1) return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer classList to $.' + node.callee.property.name
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-clone.js
+++ b/rules/no-clone.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'clone') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer cloneNode to $.clone'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'clone') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer cloneNode to $.clone'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-closest.js
+++ b/rules/no-closest.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'closest') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer closest to $.closest'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'closest') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer closest to $.closest'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-css.js
+++ b/rules/no-css.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'css') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer getComputedStyle to $.css'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'css') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer getComputedStyle to $.css'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-data.js
+++ b/rules/no-data.js
@@ -2,23 +2,28 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (!utils.isjQuery(node)) return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      const name = node.callee.property.name
-      switch (name) {
-        case 'data':
-        case 'removeData':
-          context.report({
-            node: node,
-            message: 'Prefer WeakMap to $.' + name
-          })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (!utils.isjQuery(node)) return
+
+        const name = node.callee.property.name
+        switch (name) {
+          case 'data':
+          case 'removeData':
+            context.report({
+              node: node,
+              message: 'Prefer WeakMap to $.' + name
+            })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-deferred.js
+++ b/rules/no-deferred.js
@@ -1,21 +1,26 @@
 'use strict'
 
-module.exports = function(context) {
-  function enforce(node) {
-    if (node.callee.type !== 'MemberExpression') return
-    if (node.callee.object.name !== '$') return
-    if (node.callee.property.name !== 'Deferred') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-    context.report({
-      node: node,
-      message: 'Prefer Promise to $.Deferred'
-    })
-  }
+  create: function(context) {
+    function enforce(node) {
+      if (node.callee.type !== 'MemberExpression') return
+      if (node.callee.object.name !== '$') return
+      if (node.callee.property.name !== 'Deferred') return
 
-  return {
-    CallExpression: enforce,
-    NewExpression: enforce
+      context.report({
+        node: node,
+        message: 'Prefer Promise to $.Deferred'
+      })
+    }
+
+    return {
+      CallExpression: enforce,
+      NewExpression: enforce
+    }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-delegate.js
+++ b/rules/no-delegate.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'delegate') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer addEventListener to $.delegate'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'delegate') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer addEventListener to $.delegate'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-each.js
+++ b/rules/no-each.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'each') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer Array#forEach to $.each'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'each') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer Array#forEach to $.each'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-fade.js
+++ b/rules/no-fade.js
@@ -2,22 +2,27 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  const forbidden = ['fadeIn', 'fadeOut', 'fadeTo', 'fadeToggle']
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (forbidden.indexOf(node.callee.property.name) === -1) return
+  create: function(context) {
+    const forbidden = ['fadeIn', 'fadeOut', 'fadeTo', 'fadeToggle']
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.' + node.callee.property.name + ' is not allowed'
-        })
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (forbidden.indexOf(node.callee.property.name) === -1) return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.' + node.callee.property.name + ' is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-filter.js
+++ b/rules/no-filter.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'filter') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer Array#filter to $.filter'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'filter') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer Array#filter to $.filter'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-find.js
+++ b/rules/no-find.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'find') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer querySelectorAll to $.find'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'find') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer querySelectorAll to $.find'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-global-eval.js
+++ b/rules/no-global-eval.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'globalEval') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: '$.globalEval is not allowed'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'globalEval') return
+
+        context.report({
+          node: node,
+          message: '$.globalEval is not allowed'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-has.js
+++ b/rules/no-has.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'has') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.has is not allowed'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'has') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.has is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-hide.js
+++ b/rules/no-hide.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'hide') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.hide is not allowed'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'hide') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.hide is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-html.js
+++ b/rules/no-html.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'html') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer innerHTML to $.html'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'html') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer innerHTML to $.html'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-in-array.js
+++ b/rules/no-in-array.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'inArray') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer Array#indexOf to $.inArray'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'inArray') return
+
+        context.report({
+          node: node,
+          message: 'Prefer Array#indexOf to $.inArray'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-is.js
+++ b/rules/no-is.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'is') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer matches to $.is'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'is') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer matches to $.is'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-load.js
+++ b/rules/no-load.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'load') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer fetch to $.load'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'load') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer fetch to $.load'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-map.js
+++ b/rules/no-map.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'map') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer Array#map to $.map'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'map') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer Array#map to $.map'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-merge.js
+++ b/rules/no-merge.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'merge') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer Array#concat to $.merge'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'merge') return
+
+        context.report({
+          node: node,
+          message: 'Prefer Array#concat to $.merge'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-param.js
+++ b/rules/no-param.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'param') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer FormData or URLSearchParams to $.param'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'param') return
+
+        context.report({
+          node: node,
+          message: 'Prefer FormData or URLSearchParams to $.param'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-parent.js
+++ b/rules/no-parent.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'parent') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer parentElement to $.parent'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'parent') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer parentElement to $.parent'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-parents.js
+++ b/rules/no-parents.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'parents') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer closest to $.parents'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'parents') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer closest to $.parents'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-parse-html.js
+++ b/rules/no-parse-html.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'parseHTML') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer createHTMLDocument to $.parseHTML'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'parseHTML') return
+
+        context.report({
+          node: node,
+          message: 'Prefer createHTMLDocument to $.parseHTML'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-prop.js
+++ b/rules/no-prop.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'prop') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer direct property access to $.prop'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'prop') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer direct property access to $.prop'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-proxy.js
+++ b/rules/no-proxy.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'proxy') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer Function#bind to $.proxy'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'proxy') return
+
+        context.report({
+          node: node,
+          message: 'Prefer Function#bind to $.proxy'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-ready.js
+++ b/rules/no-ready.js
@@ -21,17 +21,22 @@ function isChained(node) {
   )
 }
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (isDirect(node) || isChained(node)) {
-        context.report({
-          node: node,
-          message: '$.ready is not allowed'
-        })
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
+
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (isDirect(node) || isChained(node)) {
+          context.report({
+            node: node,
+            message: '$.ready is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-serialize.js
+++ b/rules/no-serialize.js
@@ -2,24 +2,29 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  const forbidden = ['serialize', 'serializeArray']
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (forbidden.indexOf(node.callee.property.name) === -1) return
+  create: function(context) {
+    const forbidden = ['serialize', 'serializeArray']
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message:
-            'Prefer FormData or URLSearchParams to $.' +
-            node.callee.property.name
-        })
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (forbidden.indexOf(node.callee.property.name) === -1) return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message:
+              'Prefer FormData or URLSearchParams to $.' +
+              node.callee.property.name
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-show.js
+++ b/rules/no-show.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'show') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.show is not allowed'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'show') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.show is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-size.js
+++ b/rules/no-size.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'size') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer length to $.size'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'size') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer length to $.size'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-sizzle.js
+++ b/rules/no-sizzle.js
@@ -2,46 +2,51 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  const forbidden = /:animated|:button|:checkbox|:eq|:even|:file|:first([^-]|$)|:gt|:has|:header|:hidden|:image|:input|:last([^-]|$)|:lt|:odd|:parent|:password|:radio|:reset|:selected|:submit|:text|:visible/
-  const traversals = [
-    'children',
-    'closest',
-    'filter',
-    'find',
-    'has',
-    'is',
-    'next',
-    'nextAll',
-    'nextUntil',
-    'not',
-    'parent',
-    'parents',
-    'parentsUntil',
-    'prev',
-    'prevAll',
-    'prevUntil',
-    'siblings'
-  ]
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    CallExpression: function(node) {
-      if (!node.arguments[0]) return
-      if (!utils.isjQuery(node)) return
-      if (
-        node.callee.type === 'MemberExpression' &&
-        traversals.indexOf(node.callee.property.name) === -1
-      )
-        return
+  create: function(context) {
+    const forbidden = /:animated|:button|:checkbox|:eq|:even|:file|:first([^-]|$)|:gt|:has|:header|:hidden|:image|:input|:last([^-]|$)|:lt|:odd|:parent|:password|:radio|:reset|:selected|:submit|:text|:visible/
+    const traversals = [
+      'children',
+      'closest',
+      'filter',
+      'find',
+      'has',
+      'is',
+      'next',
+      'nextAll',
+      'nextUntil',
+      'not',
+      'parent',
+      'parents',
+      'parentsUntil',
+      'prev',
+      'prevAll',
+      'prevUntil',
+      'siblings'
+    ]
 
-      if (forbidden.test(node.arguments[0].value)) {
-        context.report({
-          node: node,
-          message: 'Selector extensions are not allowed'
-        })
+    return {
+      CallExpression: function(node) {
+        if (!node.arguments[0]) return
+        if (!utils.isjQuery(node)) return
+        if (
+          node.callee.type === 'MemberExpression' &&
+          traversals.indexOf(node.callee.property.name) === -1
+        )
+          return
+
+        if (forbidden.test(node.arguments[0].value)) {
+          context.report({
+            node: node,
+            message: 'Selector extensions are not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-slide.js
+++ b/rules/no-slide.js
@@ -2,22 +2,27 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  const forbidden = ['slideDown', 'slideToggle', 'slideUp']
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (forbidden.indexOf(node.callee.property.name) === -1) return
+  create: function(context) {
+    const forbidden = ['slideDown', 'slideToggle', 'slideUp']
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.' + node.callee.property.name + ' is not allowed'
-        })
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (forbidden.indexOf(node.callee.property.name) === -1) return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.' + node.callee.property.name + ' is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-submit.js
+++ b/rules/no-submit.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'submit') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer dispatchEvent + form.submit() to $.submit'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'submit') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer dispatchEvent + form.submit() to $.submit'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-text.js
+++ b/rules/no-text.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'text') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer textContent to $.text'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'text') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer textContent to $.text'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-toggle.js
+++ b/rules/no-toggle.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'toggle') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.toggle is not allowed'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'toggle') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.toggle is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-trigger.js
+++ b/rules/no-trigger.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'trigger') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer dispatchEvent to $.trigger'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'trigger') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer dispatchEvent to $.trigger'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-trim.js
+++ b/rules/no-trim.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'trim') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer String#trim to $.trim'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'trim') return
+
+        context.report({
+          node: node,
+          message: 'Prefer String#trim to $.trim'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-val.js
+++ b/rules/no-val.js
@@ -2,20 +2,25 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'val') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer value to $.val'
-        })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.property.name !== 'val') return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: 'Prefer value to $.val'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-when.js
+++ b/rules/no-when.js
@@ -1,18 +1,23 @@
 'use strict'
 
-module.exports = function(context) {
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'when') return
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-      context.report({
-        node: node,
-        message: 'Prefer Promise.all to $.when'
-      })
+  create: function(context) {
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.object.name !== '$') return
+        if (node.callee.property.name !== 'when') return
+
+        context.report({
+          node: node,
+          message: 'Prefer Promise.all to $.when'
+        })
+      }
     }
   }
 }
-
-module.exports.schema = []

--- a/rules/no-wrap.js
+++ b/rules/no-wrap.js
@@ -2,22 +2,27 @@
 
 const utils = require('./utils.js')
 
-module.exports = function(context) {
-  const forbidden = ['wrap', 'wrapAll', 'wrapInner', 'unwrap']
+module.exports = {
+  meta: {
+    docs: {},
+    schema: []
+  },
 
-  return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (forbidden.indexOf(node.callee.property.name) === -1) return
+  create: function(context) {
+    const forbidden = ['wrap', 'wrapAll', 'wrapInner', 'unwrap']
 
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: '$.' + node.callee.property.name + ' is not allowed'
-        })
+    return {
+      CallExpression: function(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (forbidden.indexOf(node.callee.property.name) === -1) return
+
+        if (utils.isjQuery(node)) {
+          context.report({
+            node: node,
+            message: '$.' + node.callee.property.name + ' is not allowed'
+          })
+        }
       }
     }
   }
 }
-
-module.exports.schema = []


### PR DESCRIPTION
This PR refactors the codebase to use ESLint's ["new rule format"](https://eslint.org/blog/2016/07/eslint-new-rule-format). This refactor was automated by the [eslint-transforms](https://github.com/eslint/eslint-transforms) tool. My steps for refactoring:

- `npx eslint-transforms new-rule-format rules/`
- `npx eslint . --fix`

I haven't seen any documentation from ESLint in terms of the old rule format being unsupported, but I wanted to open this PR to keep the codebase up-to-date.

There are a lot of whitespace changes in this PR, so appending `?w=1` to the PR URL will help make this PR easier to review. Thanks, let me know if you have any questions. 😃 