### PR TITLE
[RFC] Refactor shared logic into withMethod and withProperty helpers

### DIFF
--- a/rules/no-ajax.js
+++ b/rules/no-ajax.js
@@ -1,24 +1,19 @@
 'use strict'
 
+const utils = require('./utils.js')
+
 module.exports = function(context) {
   return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-
-      const name = node.callee.property.name
-      switch (name) {
-        case 'ajax':
-        case 'get':
-        case 'getJSON':
-        case 'getScript':
-        case 'post':
-          context.report({
-            node: node,
-            message: 'Prefer fetch to $.' + name
-          })
+    CallExpression: utils.withProperty(
+      ['ajax', 'get', 'getJSON', 'getScript', 'post'],
+      function(node) {
+        const name = node.callee.property.name
+        context.report({
+          node: node,
+          message: 'Prefer fetch to $.' + name
+        })
       }
-    }
+    )
   }
 }
 

--- a/rules/no-css.js
+++ b/rules/no-css.js
@@ -4,17 +4,12 @@ const utils = require('./utils.js')
 
 module.exports = function(context) {
   return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.property.name !== 'css') return
-
-      if (utils.isjQuery(node)) {
-        context.report({
-          node: node,
-          message: 'Prefer getComputedStyle to $.css'
-        })
-      }
-    }
+    CallExpression: utils.withMethod('css', function(node) {
+      context.report({
+        node: node,
+        message: 'Prefer getComputedStyle to $.css'
+      })
+    })
   }
 }
 

--- a/rules/no-deferred.js
+++ b/rules/no-deferred.js
@@ -1,16 +1,14 @@
 'use strict'
 
-module.exports = function(context) {
-  function enforce(node) {
-    if (node.callee.type !== 'MemberExpression') return
-    if (node.callee.object.name !== '$') return
-    if (node.callee.property.name !== 'Deferred') return
+const utils = require('./utils.js')
 
+module.exports = function(context) {
+  const enforce = utils.withProperty('Deferred', function(node) {
     context.report({
       node: node,
       message: 'Prefer Promise to $.Deferred'
     })
-  }
+  })
 
   return {
     CallExpression: enforce,

--- a/rules/no-global-eval.js
+++ b/rules/no-global-eval.js
@@ -1,17 +1,15 @@
 'use strict'
 
+const utils = require('./utils.js')
+
 module.exports = function(context) {
   return {
-    CallExpression: function(node) {
-      if (node.callee.type !== 'MemberExpression') return
-      if (node.callee.object.name !== '$') return
-      if (node.callee.property.name !== 'globalEval') return
-
+    CallExpression: utils.withProperty('globalEval', function(node) {
       context.report({
         node: node,
         message: '$.globalEval is not allowed'
       })
-    }
+    })
   }
 }
 

--- a/rules/utils.js
+++ b/rules/utils.js
@@ -33,7 +33,41 @@ function isjQuery(node) {
   return id && id.name.startsWith('$')
 }
 
+function withProperty(property, callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('Must provide callback function')
+  }
+
+  const properties = new Set([].concat(property))
+
+  return function(node) {
+    if (node.callee.type !== 'MemberExpression') return
+    if (node.callee.object.name !== '$') return
+    if (!properties.has(node.callee.property.name)) return
+
+    callback(node)
+  }
+}
+
+function withMethod(method, callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('Must provide callback function')
+  }
+
+  const methods = new Set([].concat(method))
+
+  return function(node) {
+    if (node.callee.type !== 'MemberExpression') return
+    if (!methods.has(node.callee.property.name)) return
+    if (isjQuery(node)) {
+      callback(node)
+    }
+  }
+}
+
 module.exports = {
   traverse: traverse,
-  isjQuery: isjQuery
+  isjQuery: isjQuery,
+  withMethod: withMethod,
+  withProperty: withProperty
 }


### PR DESCRIPTION
Thinking about supporting the request in #18, it would currently require a lot of similar changes to each rule to support different jQuery aliases.

What are your thoughts on a refactor to include a couple of util functions to encapsulate shared business logic so that it's easier to add new rules and also make changes like the request in #18 with fewer code changes down the line?

I know this plugin is in a pretty stable state and supports a lot of jQuery cases already, so I would understand if you are not interested in sweeping changes, but thought I would open a WIP PR to highlight these APIs (comments inline) and see what your thoughts are. Thanks!