### PR TITLE
Detect jQuery usages from ThisExpression - this.$<propertyName>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -504,14 +504,14 @@
       "dev": true
     },
     "espree": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
-      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
+      "integrity": "sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==",
       "dev": true,
       "requires": {
-        "acorn": "^7.2.0",
+        "acorn": "^7.3.1",
         "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.2.0"
+        "eslint-visitor-keys": "^1.3.0"
       }
     },
     "esprima": {

--- a/rules/no-ajax-events.js
+++ b/rules/no-ajax-events.js
@@ -18,10 +18,21 @@ const Literal = 'Literal'
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (
@@ -33,7 +44,7 @@ module.exports = {
           if (
             arg.type === Literal &&
             arg.value in disallowedEvents &&
-            utils.isjQuery(node)
+            utils.isjQuery(node, config)
           ) {
             context.report({
               node: node,

--- a/rules/no-ajax.js
+++ b/rules/no-ajax.js
@@ -3,7 +3,17 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {

--- a/rules/no-animate.js
+++ b/rules/no-animate.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+const config = context.options[0] || {};
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'animate') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.animate is not allowed'

--- a/rules/no-animate.js
+++ b/rules/no-animate.js
@@ -19,7 +19,7 @@ module.exports = {
   },
 
   create: function (context) {
-const config = context.options[0] || {};
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-attr.js
+++ b/rules/no-attr.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'attr') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           const getOrSet = node.arguments.length === 2 ? 'set' : 'get'
           context.report({
             node: node,

--- a/rules/no-bind.js
+++ b/rules/no-bind.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'bind') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer addEventListener to $.bind'

--- a/rules/no-class.js
+++ b/rules/no-class.js
@@ -5,10 +5,21 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     const forbidden = ['addClass', 'hasClass', 'removeClass', 'toggleClass']
 
     return {
@@ -16,7 +27,7 @@ module.exports = {
         if (node.callee.type !== 'MemberExpression') return
         if (forbidden.indexOf(node.callee.property.name) === -1) return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer classList to $.' + node.callee.property.name

--- a/rules/no-clone.js
+++ b/rules/no-clone.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'clone') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer cloneNode to $.clone'

--- a/rules/no-closest.js
+++ b/rules/no-closest.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'closest') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer closest to $.closest'

--- a/rules/no-css.js
+++ b/rules/no-css.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'css') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer getComputedStyle to $.css'

--- a/rules/no-data.js
+++ b/rules/no-data.js
@@ -5,14 +5,25 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
-        if (!utils.isjQuery(node)) return
+        if (!utils.isjQuery(node, config)) return
 
         const name = node.callee.property.name
         switch (name) {

--- a/rules/no-deferred.js
+++ b/rules/no-deferred.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     function enforce(node) {
       if (node.callee.type !== 'MemberExpression') return
       if (node.callee.object.name !== '$') return

--- a/rules/no-delegate.js
+++ b/rules/no-delegate.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'delegate') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer addEventListener to $.delegate'

--- a/rules/no-each.js
+++ b/rules/no-each.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+const config = context.options[0] || {};
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'each') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer Array#forEach to $.each'

--- a/rules/no-each.js
+++ b/rules/no-each.js
@@ -19,7 +19,7 @@ module.exports = {
   },
 
   create: function (context) {
-const config = context.options[0] || {};
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-extend.js
+++ b/rules/no-extend.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-fade.js
+++ b/rules/no-fade.js
@@ -5,10 +5,21 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     const forbidden = ['fadeIn', 'fadeOut', 'fadeTo', 'fadeToggle']
 
     return {
@@ -16,7 +27,7 @@ module.exports = {
         if (node.callee.type !== 'MemberExpression') return
         if (forbidden.indexOf(node.callee.property.name) === -1) return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.' + node.callee.property.name + ' is not allowed'

--- a/rules/no-filter.js
+++ b/rules/no-filter.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'filter') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer Array#filter to $.filter'

--- a/rules/no-find.js
+++ b/rules/no-find.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'find') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer querySelectorAll to $.find'

--- a/rules/no-global-eval.js
+++ b/rules/no-global-eval.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-grep.js
+++ b/rules/no-grep.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-has.js
+++ b/rules/no-has.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'has') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.has is not allowed'

--- a/rules/no-hide.js
+++ b/rules/no-hide.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'hide') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.hide is not allowed'

--- a/rules/no-html.js
+++ b/rules/no-html.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'html') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer innerHTML to $.html'

--- a/rules/no-in-array.js
+++ b/rules/no-in-array.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-is-array.js
+++ b/rules/no-is-array.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-is-function.js
+++ b/rules/no-is-function.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-is.js
+++ b/rules/no-is.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'is') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer matches to $.is'

--- a/rules/no-load.js
+++ b/rules/no-load.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'load') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer fetch to $.load'

--- a/rules/no-map.js
+++ b/rules/no-map.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'map') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer Array#map to $.map'

--- a/rules/no-merge.js
+++ b/rules/no-merge.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-param.js
+++ b/rules/no-param.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-parent.js
+++ b/rules/no-parent.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'parent') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer parentElement to $.parent'

--- a/rules/no-parents.js
+++ b/rules/no-parents.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'parents') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer closest to $.parents'

--- a/rules/no-parse-html.js
+++ b/rules/no-parse-html.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-prop.js
+++ b/rules/no-prop.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'prop') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer direct property access to $.prop'

--- a/rules/no-proxy.js
+++ b/rules/no-proxy.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-ready.js
+++ b/rules/no-ready.js
@@ -3,7 +3,7 @@
 const utils = require('./utils.js')
 
 // $(function(){})
-function isDirect(node) {
+function isDirect(node, config) {
   return (
     node.callee.type === 'Identifier' &&
     node.callee.name === '$' &&
@@ -14,24 +14,35 @@ function isDirect(node) {
 }
 
 // $(document).ready()
-function isChained(node) {
+function isChained(node, config) {
   return (
     node.callee.type === 'MemberExpression' &&
     node.callee.property.name === 'ready' &&
-    utils.isjQuery(node)
+    utils.isjQuery(node, config)
   )
 }
 
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
-        if (isDirect(node) || isChained(node)) {
+        if (isDirect(node, config) || isChained(node, config)) {
           context.report({
             node: node,
             message: '$.ready is not allowed'

--- a/rules/no-ready.js
+++ b/rules/no-ready.js
@@ -3,7 +3,7 @@
 const utils = require('./utils.js')
 
 // $(function(){})
-function isDirect(node, config) {
+function isDirect(node) {
   return (
     node.callee.type === 'Identifier' &&
     node.callee.name === '$' &&
@@ -42,7 +42,7 @@ module.exports = {
     const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
-        if (isDirect(node, config) || isChained(node, config)) {
+        if (isDirect(node) || isChained(node, config)) {
           context.report({
             node: node,
             message: '$.ready is not allowed'

--- a/rules/no-serialize.js
+++ b/rules/no-serialize.js
@@ -5,10 +5,21 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     const forbidden = ['serialize', 'serializeArray']
 
     return {
@@ -16,7 +27,7 @@ module.exports = {
         if (node.callee.type !== 'MemberExpression') return
         if (forbidden.indexOf(node.callee.property.name) === -1) return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message:

--- a/rules/no-show.js
+++ b/rules/no-show.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+const config = context.options[0] || {};
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'show') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.show is not allowed'

--- a/rules/no-show.js
+++ b/rules/no-show.js
@@ -19,7 +19,7 @@ module.exports = {
   },
 
   create: function (context) {
-const config = context.options[0] || {};
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-size.js
+++ b/rules/no-size.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'size') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer length to $.size'

--- a/rules/no-sizzle.js
+++ b/rules/no-sizzle.js
@@ -5,10 +5,21 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+const config = context.options[0] || {};
     const forbidden = /:animated|:button|:checkbox|:eq|:even|:file|:first([^-]|$)|:gt|:has|:header|:hidden|:image|:input|:last([^-]|$)|:lt|:odd|:parent|:password|:radio|:reset|:selected|:submit|:text|:visible/
     const traversals = [
       'children',
@@ -33,7 +44,7 @@ module.exports = {
     return {
       CallExpression: function (node) {
         if (!node.arguments[0]) return
-        if (!utils.isjQuery(node)) return
+        if (!utils.isjQuery(node, config)) return
         if (
           node.callee.type === 'MemberExpression' &&
           traversals.indexOf(node.callee.property.name) === -1

--- a/rules/no-sizzle.js
+++ b/rules/no-sizzle.js
@@ -19,7 +19,7 @@ module.exports = {
   },
 
   create: function (context) {
-const config = context.options[0] || {};
+    const config = context.options[0] || {}
     const forbidden = /:animated|:button|:checkbox|:eq|:even|:file|:first([^-]|$)|:gt|:has|:header|:hidden|:image|:input|:last([^-]|$)|:lt|:odd|:parent|:password|:radio|:reset|:selected|:submit|:text|:visible/
     const traversals = [
       'children',

--- a/rules/no-slide.js
+++ b/rules/no-slide.js
@@ -5,10 +5,21 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     const forbidden = ['slideDown', 'slideToggle', 'slideUp']
 
     return {
@@ -16,7 +27,7 @@ module.exports = {
         if (node.callee.type !== 'MemberExpression') return
         if (forbidden.indexOf(node.callee.property.name) === -1) return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.' + node.callee.property.name + ' is not allowed'

--- a/rules/no-submit.js
+++ b/rules/no-submit.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'submit') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer dispatchEvent + form.submit() to $.submit'

--- a/rules/no-text.js
+++ b/rules/no-text.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'text') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer textContent to $.text'

--- a/rules/no-toggle.js
+++ b/rules/no-toggle.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'toggle') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.toggle is not allowed'

--- a/rules/no-trigger.js
+++ b/rules/no-trigger.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'trigger') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer dispatchEvent to $.trigger'

--- a/rules/no-trim.js
+++ b/rules/no-trim.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-val.js
+++ b/rules/no-val.js
@@ -5,16 +5,27 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return
         if (node.callee.property.name !== 'val') return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: 'Prefer value to $.val'

--- a/rules/no-when.js
+++ b/rules/no-when.js
@@ -3,10 +3,22 @@
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    // eslint-disable-next-line no-unused-vars
+    const config = context.options[0] || {}
     return {
       CallExpression: function (node) {
         if (node.callee.type !== 'MemberExpression') return

--- a/rules/no-wrap.js
+++ b/rules/no-wrap.js
@@ -5,10 +5,21 @@ const utils = require('./utils.js')
 module.exports = {
   meta: {
     docs: {},
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          validateThis: {
+            default: false,
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
 
   create: function (context) {
+    const config = context.options[0] || {}
     const forbidden = ['wrap', 'wrapAll', 'wrapInner', 'unwrap']
 
     return {
@@ -16,7 +27,7 @@ module.exports = {
         if (node.callee.type !== 'MemberExpression') return
         if (forbidden.indexOf(node.callee.property.name) === -1) return
 
-        if (utils.isjQuery(node)) {
+        if (utils.isjQuery(node, config)) {
           context.report({
             node: node,
             message: '$.' + node.callee.property.name + ' is not allowed'

--- a/rules/utils.js
+++ b/rules/utils.js
@@ -1,12 +1,15 @@
 'use strict'
 
-function traverse(node) {
+function traverse(node, config) {
   while (node) {
     switch (node.type) {
       case 'CallExpression':
         node = node.callee
         break
       case 'MemberExpression':
+        if (config.validateThis && node.object.type === 'ThisExpression') {
+          return node.property
+        }
         node = node.object
         break
       case 'Identifier':
@@ -25,11 +28,11 @@ function traverse(node) {
 // Examples
 //
 //   // $('div').find('p').first()
-//   isjQuery(firstNode) // => true
+//   isjQuery(firstNode, options) // => true
 //
 // Returns true if the function call node is attached to a jQuery element set.
-function isjQuery(node) {
-  const id = traverse(node)
+function isjQuery(node, config) {
+  const id = traverse(node, config)
   return id && id.name.startsWith('$')
 }
 

--- a/tests/no-ajax-events.js
+++ b/tests/no-ajax-events.js
@@ -10,7 +10,17 @@ ruleTester.run('no-ajax-events', rule, {
     '$form.on("submit", function(e){ })',
     '$form.on()',
     'on("ajaxSuccess", ".js-select-menu", function(e){ })',
-    'form.on("ajaxSend")'
+    'form.on("ajaxSend")',
+    {
+      code: 'this.$form.on("ajaxStop", function(e){ })',
+      errors: [
+        {
+          message: 'Prefer remoteForm to ajaxStop',
+          type: 'CallExpression'
+        }
+      ],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -66,6 +76,16 @@ ruleTester.run('no-ajax-events', rule, {
           type: 'CallExpression'
         }
       ]
+    },
+    {
+      code: 'this.$form.on("ajaxStop", function(e){ })',
+      errors: [
+        {
+          message: 'Prefer remoteForm to ajaxStop',
+          type: 'CallExpression'
+        }
+      ],
+      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-animate.js
+++ b/tests/no-animate.js
@@ -7,7 +7,17 @@ const error = '$.animate is not allowed'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-animate', rule, {
-  valid: ['animate()', '[].animate()', 'div.animate()', 'div.animate'],
+  valid: [
+    'animate()',
+    '[].animate()',
+    'div.animate()',
+    'div.animate',
+    {
+      code: 'this.$div.animate()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").animate()',
@@ -16,6 +26,11 @@ ruleTester.run('no-animate', rule, {
     {
       code: '$div.animate()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.animate()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().animate()',

--- a/tests/no-attr.js
+++ b/tests/no-attr.js
@@ -8,7 +8,17 @@ const setError = 'Prefer setAttribute to $.attr'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-attr', rule, {
-  valid: ['attr()', '[].attr()', 'div.attr()', 'div.attr'],
+  valid: [
+    'attr()',
+    '[].attr()',
+    'div.attr()',
+    'div.attr',
+    {
+      code: 'this.$el.attr("name", "random")',
+      errors: [{message: setError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").attr()',
@@ -33,6 +43,11 @@ ruleTester.run('no-attr', rule, {
     {
       code: '$("div").attr("name", "random")',
       errors: [{message: setError, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$el.attr("name", "random")',
+      errors: [{message: setError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-bind.js
+++ b/tests/no-bind.js
@@ -7,7 +7,17 @@ const error = 'Prefer addEventListener to $.bind'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-bind', rule, {
-  valid: ['bind()', '[].bind()', 'div.bind()', 'div.bind'],
+  valid: [
+    'bind()',
+    '[].bind()',
+    'div.bind()',
+    'div.bind',
+    {
+      code: 'this.$div.bind()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").bind()',
@@ -16,6 +26,11 @@ ruleTester.run('no-bind', rule, {
     {
       code: '$div.bind()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.bind()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().bind()',

--- a/tests/no-class.js
+++ b/tests/no-class.js
@@ -29,7 +29,12 @@ ruleTester.run('no-class', rule, {
     'toggleClass()',
     '[].toggleClass()',
     'div.toggleClass()',
-    'div.toggleClass'
+    'div.toggleClass',
+    {
+      code: 'this.$div.addClass()',
+      errors: [{message: toggleError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -37,8 +42,9 @@ ruleTester.run('no-class', rule, {
       errors: [{message: addError, type: 'CallExpression'}]
     },
     {
-      code: '$div.addClass()',
-      errors: [{message: addError, type: 'CallExpression'}]
+      code: 'this.$div.addClass()',
+      errors: [{message: addError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().addClass()',

--- a/tests/no-clone.js
+++ b/tests/no-clone.js
@@ -7,7 +7,17 @@ const error = 'Prefer cloneNode to $.clone'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-clone', rule, {
-  valid: ['clone()', '[].clone()', 'div.clone()', 'div.clone'],
+  valid: [
+    'clone()',
+    '[].clone()',
+    'div.clone()',
+    'div.clone',
+    {
+      code: 'this.$div.clone()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").clone()',
@@ -16,6 +26,11 @@ ruleTester.run('no-clone', rule, {
     {
       code: '$div.clone()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: '$div.clone()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().clone()',

--- a/tests/no-clone.js
+++ b/tests/no-clone.js
@@ -28,7 +28,7 @@ ruleTester.run('no-clone', rule, {
       errors: [{message: error, type: 'CallExpression'}]
     },
     {
-      code: '$div.clone()',
+      code: 'this.$div.clone()',
       errors: [{message: error, type: 'CallExpression'}],
       options: [{validateThis: true}]
     },

--- a/tests/no-closest.js
+++ b/tests/no-closest.js
@@ -39,11 +39,6 @@ ruleTester.run('no-closest', rule, {
     {
       code: '$("div").append($("input").closest())',
       errors: [{message: error, type: 'CallExpression'}]
-    },
-    {
-      code: 'this.$div.append($("input").closest())',
-      errors: [{message: error, type: 'CallExpression'}],
-      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-closest.js
+++ b/tests/no-closest.js
@@ -7,7 +7,17 @@ const error = 'Prefer closest to $.closest'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-closest', rule, {
-  valid: ['closest()', '[].closest()', 'div.closest()', 'div.closest'],
+  valid: [
+    'closest()',
+    '[].closest()',
+    'div.closest()',
+    'div.closest',
+    {
+      code: 'this.$div.closest()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").closest()',
@@ -18,12 +28,22 @@ ruleTester.run('no-closest', rule, {
       errors: [{message: error, type: 'CallExpression'}]
     },
     {
+      code: 'this.$div.closest()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
+    },
+    {
       code: '$("div").first().closest()',
       errors: [{message: error, type: 'CallExpression'}]
     },
     {
       code: '$("div").append($("input").closest())',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.append($("input").closest())',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-css.js
+++ b/tests/no-css.js
@@ -7,7 +7,13 @@ const error = 'Prefer getComputedStyle to $.css'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-css', rule, {
-  valid: ['css()', '[].css()', 'div.css()', 'div.css'],
+  valid: [
+    {
+      code: 'this.$el.css()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").css()',
@@ -24,6 +30,11 @@ ruleTester.run('no-css', rule, {
     {
       code: '$("div").append($("input").css())',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$el.css()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-data.js
+++ b/tests/no-data.js
@@ -17,7 +17,12 @@ ruleTester.run('no-data', rule, {
     'removeData()',
     '[].removeData()',
     'div.removeData()',
-    'div.removeData'
+    'div.removeData',
+    {
+      code: 'this.$div.removeData()',
+      errors: [{message: removeError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -43,6 +48,11 @@ ruleTester.run('no-data', rule, {
     {
       code: '$div.removeData()',
       errors: [{message: removeError, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.removeData()',
+      errors: [{message: removeError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-delegate.js
+++ b/tests/no-delegate.js
@@ -7,7 +7,17 @@ const error = 'Prefer addEventListener to $.delegate'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-delegate', rule, {
-  valid: ['delegate()', '[].delegate()', 'div.delegate()', 'div.delegate'],
+  valid: [
+    'delegate()',
+    '[].delegate()',
+    'div.delegate()',
+    'div.delegate',
+    {
+      code: 'this.$div.delegate()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").delegate()',
@@ -16,6 +26,11 @@ ruleTester.run('no-delegate', rule, {
     {
       code: '$div.delegate()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.delegate()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().delegate()',

--- a/tests/no-each.js
+++ b/tests/no-each.js
@@ -7,7 +7,17 @@ const error = 'Prefer Array#forEach to $.each'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-each', rule, {
-  valid: ['each()', '[].each()', 'div.each()', 'div.each'],
+  valid: [
+    'each()',
+    '[].each()',
+    'div.each()',
+    'div.each',
+    {
+      code: 'this.$div.each()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$.each()',
@@ -20,6 +30,11 @@ ruleTester.run('no-each', rule, {
     {
       code: '$div.each()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.each()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().each()',

--- a/tests/no-fade.js
+++ b/tests/no-fade.js
@@ -29,7 +29,12 @@ ruleTester.run('no-fade', rule, {
     'fadeToggle()',
     '[].fadeToggle()',
     'div.fadeToggle()',
-    'div.fadeToggle'
+    'div.fadeToggle',
+    {
+      code: 'this.$div.fadeIn()',
+      errors: [{message: inError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -39,6 +44,11 @@ ruleTester.run('no-fade', rule, {
     {
       code: '$div.fadeIn()',
       errors: [{message: inError, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.fadeIn()',
+      errors: [{message: inError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().fadeIn()',

--- a/tests/no-filter.js
+++ b/tests/no-filter.js
@@ -7,7 +7,17 @@ const error = 'Prefer Array#filter to $.filter'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-filter', rule, {
-  valid: ['filter()', '[].filter()', 'div.filter()', 'div.filter'],
+  valid: [
+    'filter()',
+    '[].filter()',
+    'div.filter()',
+    'div.filter',
+    {
+      code: 'this.$div.filter()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").filter()',
@@ -16,6 +26,11 @@ ruleTester.run('no-filter', rule, {
     {
       code: '$div.filter()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.filter()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().filter()',

--- a/tests/no-find.js
+++ b/tests/no-find.js
@@ -7,7 +7,17 @@ const error = 'Prefer querySelectorAll to $.find'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-find', rule, {
-  valid: ['find()', '[].find()', 'div.find()', 'div.find'],
+  valid: [
+    'find()',
+    '[].find()',
+    'div.find()',
+    'div.find',
+    {
+      code: 'this.$div.find()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").find()',
@@ -16,6 +26,11 @@ ruleTester.run('no-find', rule, {
     {
       code: '$div.find()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.find()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().find()',

--- a/tests/no-has.js
+++ b/tests/no-has.js
@@ -7,7 +7,17 @@ const error = '$.has is not allowed'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-has', rule, {
-  valid: ['has()', '[].has()', 'div.has()', 'div.has'],
+  valid: [
+    'has()',
+    '[].has()',
+    'div.has()',
+    'div.has',
+    {
+      code: 'this.$div.has()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").has()',
@@ -16,6 +26,11 @@ ruleTester.run('no-has', rule, {
     {
       code: '$div.has()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.has()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().has()',

--- a/tests/no-hide.js
+++ b/tests/no-hide.js
@@ -7,7 +7,17 @@ const error = '$.hide is not allowed'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-hide', rule, {
-  valid: ['hide()', '[].hide()', 'div.hide()', 'div.hide'],
+  valid: [
+    'hide()',
+    '[].hide()',
+    'div.hide()',
+    'div.hide',
+    {
+      code: 'this.$div.hide()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").hide()',
@@ -16,6 +26,11 @@ ruleTester.run('no-hide', rule, {
     {
       code: '$div.hide()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.hide()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().hide()',

--- a/tests/no-html.js
+++ b/tests/no-html.js
@@ -7,7 +7,17 @@ const error = 'Prefer innerHTML to $.html'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-html', rule, {
-  valid: ['html()', '[].html()', 'div.html()', 'div.html'],
+  valid: [
+    'html()',
+    '[].html()',
+    'div.html()',
+    'div.html',
+    {
+      code: 'this.$div.html()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").html()',
@@ -16,6 +26,11 @@ ruleTester.run('no-html', rule, {
     {
       code: '$div.html()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.html()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().html()',

--- a/tests/no-is.js
+++ b/tests/no-is.js
@@ -7,7 +7,17 @@ const error = 'Prefer matches to $.is'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-is', rule, {
-  valid: ['is()', '[].is()', 'div.is()', 'div.is'],
+  valid: [
+    'is()',
+    '[].is()',
+    'div.is()',
+    'div.is',
+    {
+      code: 'this.$div.is()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").is()',
@@ -16,6 +26,11 @@ ruleTester.run('no-is', rule, {
     {
       code: '$div.is()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.is()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().is()',

--- a/tests/no-load.js
+++ b/tests/no-load.js
@@ -7,7 +7,17 @@ const error = 'Prefer fetch to $.load'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-load', rule, {
-  valid: ['load()', '[].load()', 'div.load()', 'div.load'],
+  valid: [
+    'load()',
+    '[].load()',
+    'div.load()',
+    'div.load',
+    {
+      code: 'this.$div.load()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").load()',
@@ -16,6 +26,11 @@ ruleTester.run('no-load', rule, {
     {
       code: '$div.load()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.load()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().load()',

--- a/tests/no-map.js
+++ b/tests/no-map.js
@@ -7,7 +7,17 @@ const error = 'Prefer Array#map to $.map'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-map', rule, {
-  valid: ['map()', '[].map()', 'div.map()', 'div.map'],
+  valid: [
+    'map()',
+    '[].map()',
+    'div.map()',
+    'div.map',
+    {
+      code: 'this.$div.map()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$.map()',
@@ -20,6 +30,11 @@ ruleTester.run('no-map', rule, {
     {
       code: '$div.map()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.map()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().map()',

--- a/tests/no-parent.js
+++ b/tests/no-parent.js
@@ -7,7 +7,17 @@ const error = 'Prefer parentElement to $.parent'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-parent', rule, {
-  valid: ['parent()', '[].parent()', 'div.parent()', 'div.parent'],
+  valid: [
+    'parent()',
+    '[].parent()',
+    'div.parent()',
+    'div.parent',
+    {
+      code: 'this.$div.parent()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").parent()',
@@ -16,6 +26,11 @@ ruleTester.run('no-parent', rule, {
     {
       code: '$div.parent()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.parent()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().parent()',

--- a/tests/no-parents.js
+++ b/tests/no-parents.js
@@ -7,7 +7,17 @@ const error = 'Prefer closest to $.parents'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-parents', rule, {
-  valid: ['parents()', '[].parents()', 'div.parents()', 'div.parents'],
+  valid: [
+    'parents()',
+    '[].parents()',
+    'div.parents()',
+    'div.parents',
+    {
+      code: 'this.$div.parents()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").parents()',
@@ -16,6 +26,11 @@ ruleTester.run('no-parents', rule, {
     {
       code: '$div.parents()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.parents()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().parents()',

--- a/tests/no-prop.js
+++ b/tests/no-prop.js
@@ -7,7 +7,17 @@ const error = 'Prefer direct property access to $.prop'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-prop', rule, {
-  valid: ['prop()', '[].prop()', 'div.prop()', 'div.prop'],
+  valid: [
+    'prop()',
+    '[].prop()',
+    'div.prop()',
+    'div.prop',
+    {
+      code: 'this.$div.prop()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").prop()',
@@ -16,6 +26,11 @@ ruleTester.run('no-prop', rule, {
     {
       code: '$div.prop()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.prop()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().prop()',

--- a/tests/no-ready.js
+++ b/tests/no-ready.js
@@ -16,7 +16,12 @@ ruleTester.run('no-ready', rule, {
     'div.ready',
     '$("div")',
     '$(document)',
-    '$()'
+    '$()',
+    {
+      code: 'this.$div.ready(function() { })',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -50,6 +55,11 @@ ruleTester.run('no-ready', rule, {
     {
       code: '$div.ready(function() { })',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.ready(function() { })',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("img").first().ready(function() { })',

--- a/tests/no-serialize.js
+++ b/tests/no-serialize.js
@@ -17,7 +17,12 @@ ruleTester.run('no-serialize', rule, {
     'serializeArray()',
     '[].serializeArray()',
     'div.serializeArray()',
-    'div.serializeArray'
+    'div.serializeArray',
+    {
+      code: 'this.$div.serialize()',
+      errors: [{message: serializeError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -27,6 +32,11 @@ ruleTester.run('no-serialize', rule, {
     {
       code: '$div.serialize()',
       errors: [{message: serializeError, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.serialize()',
+      errors: [{message: serializeError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().serialize()',

--- a/tests/no-show.js
+++ b/tests/no-show.js
@@ -7,7 +7,17 @@ const error = '$.show is not allowed'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-show', rule, {
-  valid: ['show()', '[].show()', 'div.show()', 'div.show'],
+  valid: [
+    'show()',
+    '[].show()',
+    'div.show()',
+    'div.show',
+    {
+      code: 'this.$div.show()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").show()',
@@ -16,6 +26,11 @@ ruleTester.run('no-show', rule, {
     {
       code: '$div.show()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.show()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().show()',

--- a/tests/no-size.js
+++ b/tests/no-size.js
@@ -7,7 +7,17 @@ const error = 'Prefer length to $.size'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-size', rule, {
-  valid: ['size()', '[].size()', 'div.size()', 'div.size'],
+  valid: [
+    'size()',
+    '[].size()',
+    'div.size()',
+    'div.size',
+    {
+      code: 'this.$div.size()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").size()',
@@ -16,6 +26,11 @@ ruleTester.run('no-size', rule, {
     {
       code: '$div.size()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.size()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().size()',

--- a/tests/no-sizzle.js
+++ b/tests/no-sizzle.js
@@ -22,7 +22,12 @@ ruleTester.run('no-sizzle', rule, {
     '$(this).find($())',
     '$(this).find(function() {})',
     '$(this).find()',
-    '$(function() {})'
+    '$(function() {})',
+    {
+      code: 'this.$div.find("form input:checkbox")',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -212,6 +217,11 @@ ruleTester.run('no-sizzle', rule, {
     {
       code: '$div.find("form input:checkbox")',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.find("form input:checkbox")',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     }
   ]
 })

--- a/tests/no-slide.js
+++ b/tests/no-slide.js
@@ -23,7 +23,12 @@ ruleTester.run('no-slide', rule, {
     'slideUp()',
     '[].slideUp()',
     'div.slideUp()',
-    'div.slideUp'
+    'div.slideUp',
+    {
+      code: 'this.$div.slideToggle()',
+      errors: [{message: toggleError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -50,6 +55,11 @@ ruleTester.run('no-slide', rule, {
     {
       code: '$div.slideToggle()',
       errors: [{message: toggleError, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.slideToggle()',
+      errors: [{message: toggleError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().slideToggle()',

--- a/tests/no-submit.js
+++ b/tests/no-submit.js
@@ -7,7 +7,17 @@ const error = 'Prefer dispatchEvent + form.submit() to $.submit'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-submit', rule, {
-  valid: ['submit()', '[].submit()', 'form.submit()', 'form.submit'],
+  valid: [
+    'submit()',
+    '[].submit()',
+    'form.submit()',
+    'form.submit',
+    {
+      code: 'this.$form.submit()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("form").submit()',
@@ -16,6 +26,11 @@ ruleTester.run('no-submit', rule, {
     {
       code: '$form.submit()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$form.submit()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("form").first().submit()',

--- a/tests/no-text.js
+++ b/tests/no-text.js
@@ -7,7 +7,17 @@ const error = 'Prefer textContent to $.text'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-text', rule, {
-  valid: ['text()', '[].text()', 'div.text()', 'div.text'],
+  valid: [
+    'text()',
+    '[].text()',
+    'div.text()',
+    'div.text',
+    {
+      code: 'this.$div.text()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").text()',
@@ -16,6 +26,11 @@ ruleTester.run('no-text', rule, {
     {
       code: '$div.text()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.text()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().text()',

--- a/tests/no-toggle.js
+++ b/tests/no-toggle.js
@@ -7,7 +7,17 @@ const error = '$.toggle is not allowed'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-toggle', rule, {
-  valid: ['toggle()', '[].toggle()', 'div.toggle()', 'div.toggle'],
+  valid: [
+    'toggle()',
+    '[].toggle()',
+    'div.toggle()',
+    'div.toggle',
+    {
+      code: 'this.$div.toggle()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").toggle()',
@@ -16,6 +26,11 @@ ruleTester.run('no-toggle', rule, {
     {
       code: '$div.toggle()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.toggle()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().toggle()',

--- a/tests/no-trigger.js
+++ b/tests/no-trigger.js
@@ -7,7 +7,17 @@ const error = 'Prefer dispatchEvent to $.trigger'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-trigger', rule, {
-  valid: ['trigger()', '[].trigger()', 'div.trigger()', 'div.trigger'],
+  valid: [
+    'trigger()',
+    '[].trigger()',
+    'div.trigger()',
+    'div.trigger',
+    {
+      code: 'this.$div.trigger()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").trigger()',
@@ -16,6 +26,11 @@ ruleTester.run('no-trigger', rule, {
     {
       code: '$div.trigger()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.trigger()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().trigger()',

--- a/tests/no-val.js
+++ b/tests/no-val.js
@@ -7,7 +7,17 @@ const error = 'Prefer value to $.val'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-val', rule, {
-  valid: ['val()', '[].val()', 'div.val()', 'div.val'],
+  valid: [
+    'val()',
+    '[].val()',
+    'div.val()',
+    'div.val',
+    {
+      code: 'this.$div.val()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
+  ],
   invalid: [
     {
       code: '$("div").val()',
@@ -16,6 +26,11 @@ ruleTester.run('no-val', rule, {
     {
       code: '$div.val()',
       errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.val()',
+      errors: [{message: error, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().val()',

--- a/tests/no-wrap.js
+++ b/tests/no-wrap.js
@@ -29,7 +29,12 @@ ruleTester.run('no-wrap', rule, {
     'unwrap()',
     '[].unwrap()',
     'div.unwrap()',
-    'div.unwrap'
+    'div.unwrap',
+    {
+      code: 'this.$div.wrap()',
+      errors: [{message: wrapError, type: 'CallExpression'}],
+      options: [{validateThis: false}]
+    }
   ],
   invalid: [
     {
@@ -39,6 +44,11 @@ ruleTester.run('no-wrap', rule, {
     {
       code: '$div.wrap()',
       errors: [{message: wrapError, type: 'CallExpression'}]
+    },
+    {
+      code: 'this.$div.wrap()',
+      errors: [{message: wrapError, type: 'CallExpression'}],
+      options: [{validateThis: true}]
     },
     {
       code: '$("div").first().wrap()',


### PR DESCRIPTION
Addresses #33

## Changes
These changes update the plugin to accept a boolean `validateThis` option that determines if rules should validate against potential jQuery usages off of `this.$<propertyName>`. By default, this option is `false`, so these changes are backwards compatible. The motivation here is to use this plugin to validate a codebase with Backbone.js, where `this.$el` is a standardized reference to a jQuery-wrapped element.

```js
const myView = Backbone.View.extend({
  render() {
    this.$el.show(); // there was no warning for this before
  }
})
```

The only changes are that each rule accepts a config (see question below), that is passed along to `isjQuery` and `traverse`. If `validateThis` is enabled, `traverse` will return the property node rather than the root node for a `MemberExpression` that is a references `this.<something>`. This means that it would return the `$el` for a line that start with `this.$el`. The same logic is then used on this property within `isjQuery` to determine if it's a jQuery reference (id with `$`)

### Tests
I've added 2 tests to each applicable rule to validate that usages of `this.$foo.<disallowed-jQuery-call>()` are prevented when `validateThis` is true, but allowed when `validateThis` is false. The same test code was used for the true/false conditions of `validateThis`, but with different options.

### Open Question
This changes updates the plugin to accept the `validateThis` option config. Each rule accepts the option, despite many rules not using it.
- Should the rules that do not use `validateThis` be updated to disallow potential jQuery usage off of `this`?
  - ie: no-when does not validate for `this.$.when()` despite accepting the `validateThis` option.
- Or should I remove the unused `config` variables from rules that do not use them?
  - look for `// eslint-disable-next-line no-unused-vars` in my changes

### Usage
```js
// .eslintrc.js
"jquery/no-css": ["warn", {"validateThis":true}],
"jquery/no-clone": "warn",      // validateThis is false by default
"jquery/no-hide": ["warn", {"validateThis":false}],
```